### PR TITLE
Add skeleton pages for CordCompass

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,74 +1,38 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { useState } from 'react';
-import { css, jsx } from '@emotion/react';
-import styled from '@emotion/styled';
-import { Button } from '@mui/material';
+import { jsx } from '@emotion/react';
 
-import { useGetProjectsQuery } from '@/service/api';
+import HomePage from '@/pages/HomePage';
+import DeviceSelectionPage from '@/pages/DeviceSelectionPage';
+import SpecsSearchPage from '@/pages/SpecsSearchPage';
+import ResultsPage from '@/pages/ResultsPage';
 
-const AppContainer = styled('div')`
-  text-align: center;
-`;
+export default function App() {
+  const [page, setPage] = useState<'home' | 'device' | 'specs' | 'results'>('home');
+  const [selectedDevices, setSelectedDevices] = useState<string[]>([]);
+  const [selectedSpecs, setSelectedSpecs] = useState<{ protocol: string; length: string } | undefined>();
 
-const AppHeader = styled('header')`
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-`;
+  const showHome = () => setPage('home');
+  const handleDevices = (devices: string[]) => {
+    setSelectedDevices(devices);
+    setSelectedSpecs(undefined);
+    setPage('results');
+  };
+  const handleSpecs = (specs: { protocol: string; length: string }) => {
+    setSelectedDevices([]);
+    setSelectedSpecs(specs);
+    setPage('results');
+  };
 
-function App() {
-  const [count, setCount] = useState(0);
-  const { data, isFetching, isError, isSuccess, refetch } = useGetProjectsQuery();
-
-  return (
-    <AppContainer>
-      <AppHeader>
-        <p
-          css={css`
-            color: yellow;
-          `}
-        >
-          Hello Vite + React!
-        </p>
-        <div>
-          <p>
-            {isFetching
-              ? 'Fetching projects...'
-              : isError
-              ? 'Error fetching projects!'
-              : isSuccess
-              ? 'Successfully fetched projects!'
-              : ''}
-          </p>
-        </div>
-        <div
-          css={css`
-            opacity: ${isFetching ? 0.5 : 1};
-          `}
-        >
-          Projects: {JSON.stringify(data)}
-        </div>
-        <Button variant="contained" color="primary" onClick={refetch}>
-          Re-fetch projects
-        </Button>
-        <p>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={() => setCount((count) => count + 1)}
-          >
-            count is: {count}
-          </Button>
-        </p>
-      </AppHeader>
-    </AppContainer>
-  );
+  if (page === 'device') {
+    return <DeviceSelectionPage onSubmit={handleDevices} />;
+  }
+  if (page === 'specs') {
+    return <SpecsSearchPage onSubmit={handleSpecs} />;
+  }
+  if (page === 'results') {
+    return <ResultsPage devices={selectedDevices} specs={selectedSpecs} onBack={showHome} />;
+  }
+  return <HomePage onSelectDevices={() => setPage('device')} onSpecSearch={() => setPage('specs')} />;
 }
-
-export default App;

--- a/src/pages/DeviceSelectionPage.tsx
+++ b/src/pages/DeviceSelectionPage.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import {
+  Container,
+  Typography,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
+  Button,
+  Stack,
+} from '@mui/material';
+
+interface DeviceSelectionPageProps {
+  onSubmit: (devices: string[]) => void;
+}
+
+export default function DeviceSelectionPage({ onSubmit }: DeviceSelectionPageProps) {
+  const [devices, setDevices] = useState<string[]>([]);
+
+  const handleChange = (device: string) => {
+    setDevices((prev) =>
+      prev.includes(device) ? prev.filter((d) => d !== device) : [...prev, device]
+    );
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Stack spacing={2}>
+        <Typography variant="h5">Select your devices</Typography>
+        <FormGroup>
+          {['Phone', 'Laptop', 'Tablet'].map((device) => (
+            <FormControlLabel
+              key={device}
+              control={
+                <Checkbox
+                  checked={devices.includes(device)}
+                  onChange={() => handleChange(device)}
+                />
+              }
+              label={device}
+            />
+          ))}
+        </FormGroup>
+        <Button variant="contained" onClick={() => onSubmit(devices)}>
+          Find Cables
+        </Button>
+      </Stack>
+    </Container>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,31 @@
+import { Button, Container, Typography, Stack, AppBar, Toolbar } from '@mui/material';
+
+interface HomePageProps {
+  onSelectDevices: () => void;
+  onSpecSearch: () => void;
+}
+
+export default function HomePage({ onSelectDevices, onSpecSearch }: HomePageProps) {
+  return (
+    <>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            CordCompass
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Container sx={{ mt: 4 }}>
+        <Stack spacing={2} alignItems="center">
+          <Typography variant="h4">Find the perfect USB cable</Typography>
+          <Button variant="contained" onClick={onSelectDevices}>
+            Select Devices
+          </Button>
+          <Button variant="outlined" onClick={onSpecSearch}>
+            Search by Cable Specs
+          </Button>
+        </Stack>
+      </Container>
+    </>
+  );
+}

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -1,0 +1,50 @@
+import {
+  Container,
+  Typography,
+  Card,
+  CardContent,
+  CardActions,
+  Button,
+  Stack,
+} from '@mui/material';
+
+interface ResultsPageProps {
+  devices: string[];
+  specs?: { protocol: string; length: string };
+  onBack: () => void;
+}
+
+const sampleCables = [
+  { id: 1, name: 'Cable A', price: '$10' },
+  { id: 2, name: 'Cable B', price: '$12' },
+];
+
+export default function ResultsPage({ devices, specs, onBack }: ResultsPageProps) {
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Stack spacing={2}>
+        <Typography variant="h5">Results</Typography>
+        {devices.length > 0 && (
+          <Typography>For devices: {devices.join(', ')}</Typography>
+        )}
+        {specs && (
+          <Typography>
+            Specs: {specs.protocol} {specs.length && `- ${specs.length}m`}
+          </Typography>
+        )}
+        {sampleCables.map((cable) => (
+          <Card key={cable.id} variant="outlined">
+            <CardContent>
+              <Typography variant="h6">{cable.name}</Typography>
+              <Typography>{cable.price}</Typography>
+            </CardContent>
+            <CardActions>
+              <Button size="small">View</Button>
+            </CardActions>
+          </Card>
+        ))}
+        <Button onClick={onBack}>Back to Home</Button>
+      </Stack>
+    </Container>
+  );
+}

--- a/src/pages/SpecsSearchPage.tsx
+++ b/src/pages/SpecsSearchPage.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import {
+  Container,
+  Typography,
+  TextField,
+  Button,
+  Stack,
+  MenuItem,
+} from '@mui/material';
+
+interface Specs {
+  protocol: string;
+  length: string;
+}
+
+interface SpecsSearchPageProps {
+  onSubmit: (specs: Specs) => void;
+}
+
+export default function SpecsSearchPage({ onSubmit }: SpecsSearchPageProps) {
+  const [specs, setSpecs] = useState<Specs>({ protocol: '', length: '' });
+
+  const handleChange = (field: keyof Specs) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setSpecs((prev) => ({ ...prev, [field]: event.target.value }));
+    };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Stack spacing={2}>
+        <Typography variant="h5">Filter by specs</Typography>
+        <TextField
+          select
+          label="Protocol"
+          value={specs.protocol}
+          onChange={handleChange('protocol')}
+        >
+          {['USB 2.0', 'USB 3.0', 'USB 3.2', 'Thunderbolt'].map((p) => (
+            <MenuItem key={p} value={p}>
+              {p}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          label="Length (m)"
+          value={specs.length}
+          onChange={handleChange('length')}
+        />
+        <Button variant="contained" onClick={() => onSubmit(specs)}>
+          Find Cables
+        </Button>
+      </Stack>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple home, device selection, specs search, and results pages
- update App to navigate between pages using local state

## Testing
- `yarn test` *(fails: package not present)*